### PR TITLE
Update balanceChanges.html

### DIFF
--- a/pages/balanceChanges.html
+++ b/pages/balanceChanges.html
@@ -26,10 +26,36 @@
 
         <h2>Naval</h2>
         <div id="1">
+
+          <div id="salem" class="card">
+            <h3>Tech 2 Destroyers</h3>
+
+
+            <h4><img src="/images/units/cybran/naval/T2Destoryer.png"> Salem</h4>
+            <ul>
+              <li>BackUpDistance: <s>5</s> <i class="fa-solid fa-arrow-right"></i> 10</li>
+            </ul>
+
+            <h4><img src="/images/units/sera/naval/T2Destroyer.png"> Uashavoh</h4>
+            <ul>
+              <li>Anit-Torp ROF: <s>0.26</s> <i class="fa-solid fa-arrow-right"></i> 0.3</li>
+            </ul>
+
+          </div>
+
+          <div id="cooper" class="card">
+            <h3><img src="/images/units/uef/naval/T2TorpBoat.png"> Cooper</h3>
+            <ul>
+              <li>Health: <s>1750</s> <i class="fa-solid fa-arrow-right"></i> 2000</li>
+            </ul>
+          </div>
+
+
+
+
+
           <div id="subhunter" class="card">
-
             <h3><img src="/images/units/sera/naval/T3SubHunter.png">T3 Sub Hunter</h3>
-
             <ul>
               <li> Main Weapon:
                 <ul>


### PR DESCRIPTION
Uashavoh
AntiTorpedo RateOfFire: 0.26 --> 0.3

This unit suffered due to the buffs to torpedoes (automatic retargeting) and torpedo defenses. This slight buff aims to bring the unit's performance roughly back in line with how it was before the these changes.

Cooper
Health: 1750 --> 2000

The Cooper is a unit that is usually used relatively close to the frontlines. Unfortunately, its hit points are lower than even that of the weakest frigates, while costing around three times as much. This change gives it slightly more survivability, while still emphasizing the need to micro it properly and keep it behind your destroyers.

Salem Class
BackUpDistance: 5 --> 10