### PR TITLE
Remove unnecessary padding from the title and re-enable bullet points

### DIFF
--- a/style/balance.css
+++ b/style/balance.css
@@ -13,6 +13,7 @@ h6 {
   font-family: "Ubuntu", sans-serif;
   font-style: normal;
   font-weight: normal;
+  padding-top: 10px;
 }
 
 a {

--- a/style/balance.css
+++ b/style/balance.css
@@ -64,10 +64,6 @@ li {
   padding-left: 10px;
 }
 
-.FlexboxContainer {
-  padding-left: 10px;
-}
-
 /* Sidebar */
 .Sidebar {
   grid-column: 3; /* Positioning within the grid */

--- a/style/balance.css
+++ b/style/balance.css
@@ -26,7 +26,6 @@ ul {
 
 li {
   padding: 5px 0 5px 0;
-  list-style: none;
 }
 
 .Grid {

--- a/style/components/card.css
+++ b/style/components/card.css
@@ -4,7 +4,7 @@
     background: var(--Card);
     border-radius: 1em;
     padding: 5px 15px;
-    margin: 20px;
+    margin: 20px 0px;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
     color: var(--Text);
 }


### PR DESCRIPTION
- Make the version number in the title (e. g. Patch 3810) flush with the text beneath it.
- Re-enable bullet points for unordered lists.
- Introduce more padding for headings.
- Improve the styling of card.css.